### PR TITLE
Hex colours entered in text fields don't appear on render

### DIFF
--- a/main.js
+++ b/main.js
@@ -19,12 +19,12 @@ void function () {
     }
 
     function rgbColorFromHexString(hexString) {
-        var match = /\#?([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})/.exec(hexString)
+        var hexValues = hexString.replace(/^\#/, '')
 
-        return match === null ? null : {
-            red:    parseInt(match[1], 16),
-            green:  parseInt(match[2], 16),
-            blue:   parseInt(match[3], 16),
+        return hexValues.length !== 6 ? null : {
+            red: parseInt(hexValues.substring(0, 2), 16),
+            green: parseInt(hexValues.substring(2, 4), 16),
+            blue: parseInt(hexValues.substring(4, 6), 16),
         }
     }
 


### PR DESCRIPTION
I was using the colour matcher, and I noticed that some colours aren't being rendered when I entered them in the text field, such as `#2A312E`

This was for two reasons:

1. The colourString was being sent to `render()` directly without removing the `#` character, which was causing errors in the `rgbColorFromHexString()`.
2. The regex in `rgbColorFromHexString()` was only looking for lowercase characters. So passing a string with a `#` and uppercase characters caused it to fail.

The problem was fixed by sanitizing the string in the `rgbColorFromHexString()` _and_ replacing the regex with [`substring()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring). You could probably clean up the regex, but using `substring()` makes it really clear what's going on.

Thanks for the great script, and all the hard work! It was really useful. 
